### PR TITLE
Kobe Cranker: Setup cranker for devnet

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -248,7 +248,7 @@ async fn run_server(args: &Args) {
         .await
         .expect("Mongo connection failed.");
     let db = c.database(&args.mongo_db_name);
-    let cluster = Cluster::get_cluster(&args.solana_cluster);
+    let cluster = Cluster::get_cluster(&args.solana_cluster).expect("Failed to get cluster");
 
     let query_resolver = QueryResolver::new(&db, &args.rpc_url, cluster);
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KobeCoreError {
+    #[error(
+        "Invalid cluster value: '{0}'. Expected 'testnet', 'mainnet', 'mainnet-beta', or 'devnet'"
+    )]
+    InvalidCluster(String),
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ use crate::db_models::validators::Validator;
 pub mod client_type;
 pub mod constants;
 pub mod db_models;
+pub mod error;
 pub mod fetcher;
 pub mod mongo;
 pub mod rpc_utils;

--- a/core/src/validators_app.rs
+++ b/core/src/validators_app.rs
@@ -26,7 +26,8 @@ impl Cluster {
         match value.to_lowercase().as_ref() {
             "testnet" | "t" => Cluster::Testnet,
             "mainnet-beta" | "mainnet" | "m" => Cluster::MainnetBeta,
-            _ => Cluster::Testnet,
+            "devnet" | "d" => Cluster::Devnet,
+            _ => unreachable!(),
         }
     }
 }

--- a/core/src/validators_app.rs
+++ b/core/src/validators_app.rs
@@ -13,6 +13,8 @@ use log::*;
 use serde::{Deserialize, Serialize};
 use solana_pubkey::Pubkey;
 
+use crate::error::KobeCoreError;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Cluster {
     Devnet,
@@ -22,12 +24,12 @@ pub enum Cluster {
 
 impl Cluster {
     /// Get cluster value
-    pub fn get_cluster(value: &str) -> Cluster {
+    pub fn get_cluster(value: &str) -> Result<Cluster, KobeCoreError> {
         match value.to_lowercase().as_ref() {
-            "testnet" | "t" => Cluster::Testnet,
-            "mainnet-beta" | "mainnet" | "m" => Cluster::MainnetBeta,
-            "devnet" | "d" => Cluster::Devnet,
-            _ => unreachable!(),
+            "mainnet-beta" | "mainnet" | "m" => Ok(Cluster::MainnetBeta),
+            "testnet" | "t" => Ok(Cluster::Testnet),
+            "devnet" | "d" => Ok(Cluster::Devnet),
+            _ => return Err(KobeCoreError::InvalidCluster(value.to_string())),
         }
     }
 }

--- a/core/src/validators_app.rs
+++ b/core/src/validators_app.rs
@@ -29,7 +29,7 @@ impl Cluster {
             "mainnet-beta" | "mainnet" | "m" => Ok(Cluster::MainnetBeta),
             "testnet" | "t" => Ok(Cluster::Testnet),
             "devnet" | "d" => Ok(Cluster::Devnet),
-            _ => return Err(KobeCoreError::InvalidCluster(value.to_string())),
+            _ => Err(KobeCoreError::InvalidCluster(value.to_string())),
         }
     }
 }

--- a/cranker/src/main.rs
+++ b/cranker/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use backon::{ExponentialBuilder, Retryable};
 use clap::Parser;
 use env_logger::{Builder, Target};
+use kobe_core::validators_app::Cluster;
 use log::*;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_metrics::set_host_id;
@@ -95,6 +96,7 @@ fn main() {
 
         Config {
             rpc_client,
+            cluster: Cluster::get_cluster(&args.network),
             fee_payer,
             stake_pool_address,
             dry_run: args.dry_run,

--- a/cranker/src/main.rs
+++ b/cranker/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
 
         Config {
             rpc_client,
-            cluster: Cluster::get_cluster(&args.network),
+            cluster: Cluster::get_cluster(&args.network).expect("Failed to get cluster"),
             fee_payer,
             stake_pool_address,
             dry_run: args.dry_run,

--- a/writer-service/src/main.rs
+++ b/writer-service/src/main.rs
@@ -82,7 +82,7 @@ fn init_logger(cluster: &Cluster) -> Result<()> {
 fn main() -> Result<()> {
     dotenvy::dotenv().ok();
     let args: Args = Args::parse();
-    let cluster = Cluster::get_cluster(&args.solana_cluster);
+    let cluster = Cluster::get_cluster(&args.solana_cluster)?;
     init_logger(&cluster)?;
 
     // Set up panic alerting via Sentry

--- a/writer-service/src/result.rs
+++ b/writer-service/src/result.rs
@@ -1,6 +1,7 @@
 use std::io::Error as IoError;
 
 use backoff::Error as BackoffError;
+use kobe_core::error::KobeCoreError;
 use log::SetLoggerError;
 use mongodb::error::Error as MongoError;
 use reqwest::Error as ReqwestError;
@@ -61,6 +62,9 @@ pub enum AppError {
 
     #[error("Join errorr")]
     JoinError(#[from] tokio::task::JoinError),
+
+    #[error(transparent)]
+    KobeCore(#[from] KobeCoreError),
 }
 
 impl From<BackoffError<ClientError>> for AppError {


### PR DESCRIPTION
```bash 
RUST_LOG=info cargo r -p kobe-cranker -- \
    --fee-payer ~/.config/solana/id.json \
    --url "https://api.devnet.solana.com" \
    --network "devnet" \
    --pool-address "JitoY5pcAxWX6iyP2QdFwTznGb8A99PRCUCVVxB46WZ" \
    --sentry-api-url "" \
    --region "local"
```