### PR TITLE
Dockerfile: Remove `cargo-sort` from rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "stable"
-components = ["cargo-sort", "clippy"]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- `cargo-sort` is not an official Rust component and cannot be installed via rustup.