### PR TITLE
CI/CD: Change to `big-runner-1`

### DIFF
--- a/.github/workflows/build-container-images.yaml
+++ b/.github/workflows/build-container-images.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-container:
-    runs-on: ubuntu-latest
+    runs-on: big-runner-1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### Problem

- Took time to build and publish image of kobe

### Solution

- Changes the runner from `ubuntu-latest` to `big-runner-1` for the build-container job