### PR TITLE
BAM Writer Service: Fix BAM capable eligibility window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -4636,7 +4636,7 @@ dependencies = [
  "rustls 0.23.29",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.4",
+ "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -4661,9 +4661,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/bam-writer-service/src/bam_validator_eligibility.rs
+++ b/bam-writer-service/src/bam_validator_eligibility.rs
@@ -218,7 +218,7 @@ impl BamValidatorEligibility {
 
             if is_capable {
                 bam_capable_count += 1;
-                if connected_set.map_or(false, |s| s.contains(&epoch)) {
+                if connected_set.is_some_and(|s| s.contains(&epoch)) {
                     bam_capable_and_connected_count += 1;
                 }
             }

--- a/bam-writer-service/src/bam_validator_eligibility.rs
+++ b/bam-writer-service/src/bam_validator_eligibility.rs
@@ -211,9 +211,7 @@ impl BamValidatorEligibility {
         let mut bam_capable_count = 0usize;
         let mut bam_capable_and_connected_count = 0usize;
 
-        for (i, epoch) in
-            (self.running_bam_start_epoch..=self.running_bam_end_epoch).enumerate()
-        {
+        for (i, epoch) in (self.running_bam_start_epoch..=self.running_bam_end_epoch).enumerate() {
             let is_capable = client_types[i]
                 .map(|ct| ClientType::from_u8(ct).is_bam_capable())
                 .unwrap_or(false);

--- a/bam-writer-service/src/bam_validator_eligibility.rs
+++ b/bam-writer-service/src/bam_validator_eligibility.rs
@@ -204,25 +204,32 @@ impl BamValidatorEligibility {
             return Err(IneligibilityReason::InsufficientHistory);
         }
 
-        let bam_capable_epochs = client_types
-            .iter()
-            .flatten()
-            .filter(|client_type| ClientType::from_u8(**client_type).is_bam_capable())
-            .count();
-        if bam_capable_epochs < self.min_running_bam_epochs {
-            return Err(IneligibilityReason::NotBamClient);
+        let connected_set = self
+            .bam_connected_epochs
+            .get(&validator_history.vote_account);
+
+        let mut bam_capable_count = 0usize;
+        let mut bam_capable_and_connected_count = 0usize;
+
+        for (i, epoch) in
+            (self.running_bam_start_epoch..=self.running_bam_end_epoch).enumerate()
+        {
+            let is_capable = client_types[i]
+                .map(|ct| ClientType::from_u8(ct).is_bam_capable())
+                .unwrap_or(false);
+
+            if is_capable {
+                bam_capable_count += 1;
+                if connected_set.map_or(false, |s| s.contains(&epoch)) {
+                    bam_capable_and_connected_count += 1;
+                }
+            }
         }
 
-        let bam_connected_epochs = self
-            .bam_connected_epochs
-            .get(&validator_history.vote_account)
-            .map(|epochs| {
-                (self.running_bam_start_epoch..=self.running_bam_end_epoch)
-                    .filter(|epoch| epochs.contains(epoch))
-                    .count()
-            })
-            .unwrap_or_default();
-        if bam_connected_epochs < self.min_running_bam_epochs {
+        if bam_capable_count < self.min_running_bam_epochs {
+            return Err(IneligibilityReason::NotBamClient);
+        }
+        if bam_capable_and_connected_count < self.min_running_bam_epochs {
             return Err(IneligibilityReason::NotBamConnected);
         }
 
@@ -448,6 +455,35 @@ mod tests {
         assert!(checker
             .check_eligibility(&blacklist_validators, &steward_config, &vh)
             .is_ok());
+    }
+
+    #[test]
+    fn test_bam_capable_and_connected_must_overlap() {
+        let blacklist_validators = vec![];
+        let steward_config = create_steward_config();
+
+        // BAM-capable in epochs 96-98 (3 epochs), but BAM-connected in epochs 99-100 (different epochs).
+        // Despite having 3 capable epochs and 2 connected epochs, no single epoch is both,
+        // so the validator should fail the connected check.
+        let vh = create_validator_history(vec![
+            create_entry(95, 2, 0, 10, 0, 10000), // Firedancer (not capable)
+            create_entry(96, 1, 0, 10, 0, 10000), // JitoLabs (capable)
+            create_entry(97, 1, 0, 10, 0, 10000), // JitoLabs (capable)
+            create_entry(98, 1, 0, 10, 0, 10000), // JitoLabs (capable)
+            create_entry(99, 2, 0, 10, 0, 10000), // Firedancer (not capable)
+            create_entry(100, 2, 0, 10, 0, 10000),
+        ]);
+
+        // Connected in epochs 99-100 only (non-capable epochs)
+        let mut bam_connected_epochs = HashMap::new();
+        bam_connected_epochs.insert(vh.vote_account, HashSet::from([99_u16, 100_u16]));
+
+        let checker = BamValidatorEligibility::new(100, &[vh.clone()], bam_connected_epochs);
+
+        assert_eq!(
+            checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
+            Err(IneligibilityReason::NotBamConnected)
+        );
     }
 
     #[test]

--- a/bam-writer-service/src/bam_validator_eligibility.rs
+++ b/bam-writer-service/src/bam_validator_eligibility.rs
@@ -406,6 +406,7 @@ mod tests {
         let blacklist_validators = vec![];
         let steward_config = create_steward_config();
         let vh = create_validator_history(vec![
+            create_entry(95, 2, 0, 10, 0, 10000), // Firedancer
             create_entry(96, 2, 0, 10, 0, 10000), // Firedancer
             create_entry(97, 2, 0, 10, 0, 10000), // Firedancer
             create_entry(98, 6, 0, 10, 0, 10000),
@@ -430,7 +431,8 @@ mod tests {
         let blacklist_validators = vec![];
         let steward_config = create_steward_config();
         let vh = create_validator_history(vec![
-            create_entry(96, 1, 0, 10, 0, 10000),
+            create_entry(95, 3, 0, 10, 0, 10000),
+            create_entry(96, 3, 0, 10, 0, 10000),
             create_entry(97, 1, 0, 10, 0, 10000),
             create_entry(98, 1, 0, 10, 0, 10000),
             create_entry(99, 1, 0, 10, 0, 10000),

--- a/bam-writer-service/src/bam_validator_eligibility.rs
+++ b/bam-writer-service/src/bam_validator_eligibility.rs
@@ -7,6 +7,9 @@ use kobe_core::client_type::ClientType;
 use solana_pubkey::Pubkey;
 use validator_history::ValidatorHistory;
 
+pub(crate) const RUNNING_BAM_LOOKBACK_EPOCHS: u64 = 5;
+pub(crate) const MIN_RUNNING_BAM_EPOCHS: usize = 3;
+
 /// Validates validator eligibility for BAM delegation according to JIP-28 criteria
 #[derive(Debug)]
 pub struct BamValidatorEligibility {
@@ -85,7 +88,7 @@ impl BamValidatorEligibility {
     /// | `bam_blacklist_component` | Is the validator on the BAM blacklist (includes on-chain blacklist)? Binary component. |
     /// | `validator_commission_component` | Has the validator maintained an inflation rate of 0% the last 30 epochs? Binary component. |
     /// | `mev_commission_component` | Has the validator maintained a MEV commission rate of under 10% the last 10 epochs? Binary component. |
-    /// | `running_bam_component` | Has the validator been BAM-capable and actually BAM-connected in at least 3 of the last 5 completed epochs? Binary component. |
+    /// | `running_bam_component` | Has the validator been BAM-capable and actually BAM-connected in the BAM lookback window often enough to satisfy the configured threshold? Binary component. |
     /// | `superminority_component` | Has the validator been outside of the superminority for the last 3 epochs? Binary component. |
     /// | `voting_rate_component` | Has the validator maintained a minimum voting_rate of voting_rate_threshold for the last 3 epochs? Binary component. |
     pub fn new(
@@ -102,9 +105,10 @@ impl BamValidatorEligibility {
         let mev_commission_end_epoch = (current_epoch - 1) as u16;
 
         // Running bam
-        let running_bam_start_epoch = current_epoch.saturating_sub(5) as u16;
+        let running_bam_start_epoch =
+            current_epoch.saturating_sub(RUNNING_BAM_LOOKBACK_EPOCHS) as u16;
         let running_bam_end_epoch = (current_epoch - 1) as u16;
-        let min_running_bam_epochs = 3;
+        let min_running_bam_epochs = MIN_RUNNING_BAM_EPOCHS;
 
         // Superminority
         let superminority_start_epoch = (current_epoch - 3) as u16;
@@ -367,7 +371,7 @@ mod tests {
         current_epoch: u64,
         vote_account: Pubkey,
     ) -> HashMap<Pubkey, HashSet<u16>> {
-        let start_epoch = current_epoch.saturating_sub(5) as u16;
+        let start_epoch = current_epoch.saturating_sub(RUNNING_BAM_LOOKBACK_EPOCHS) as u16;
         let end_epoch = current_epoch.saturating_sub(1) as u16;
         let mut bam_connected_epochs = HashMap::new();
         bam_connected_epochs.insert(vote_account, (start_epoch..=end_epoch).collect());

--- a/bam-writer-service/src/bam_validator_eligibility.rs
+++ b/bam-writer-service/src/bam_validator_eligibility.rs
@@ -1,6 +1,6 @@
 //! Validator eligibility validation for BAM delegation (JIP-28)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use jito_steward::Config;
 use kobe_core::client_type::ClientType;
@@ -28,6 +28,9 @@ pub struct BamValidatorEligibility {
     /// Running bam end epoch
     running_bam_end_epoch: u16,
 
+    /// Minimum number of BAM-capable / BAM-connected epochs required in the lookback window
+    min_running_bam_epochs: usize,
+
     /// Superminority start epoch
     superminority_start_epoch: u16,
 
@@ -42,11 +45,15 @@ pub struct BamValidatorEligibility {
 
     /// Chain maximum vote credits per epoch
     chain_max_credits: HashMap<u16, u32>,
+
+    /// Epochs where a validator was observed in BAM validator snapshots
+    bam_connected_epochs: HashMap<Pubkey, HashSet<u16>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IneligibilityReason {
     NotBamClient,
+    NotBamConnected,
     NonZeroCommission {
         epoch: u16,
         commission: u8,
@@ -78,10 +85,14 @@ impl BamValidatorEligibility {
     /// | `bam_blacklist_component` | Is the validator on the BAM blacklist (includes on-chain blacklist)? Binary component. |
     /// | `validator_commission_component` | Has the validator maintained an inflation rate of 0% the last 30 epochs? Binary component. |
     /// | `mev_commission_component` | Has the validator maintained a MEV commission rate of under 10% the last 10 epochs? Binary component. |
-    /// | `running_bam_component` | Has the validator been running the BAM client for the last 3 epochs? Binary component. |
+    /// | `running_bam_component` | Has the validator been BAM-capable and actually BAM-connected in at least 3 of the last 5 completed epochs? Binary component. |
     /// | `superminority_component` | Has the validator been outside of the superminority for the last 3 epochs? Binary component. |
     /// | `voting_rate_component` | Has the validator maintained a minimum voting_rate of voting_rate_threshold for the last 3 epochs? Binary component. |
-    pub fn new(current_epoch: u64, all_validator_histories: &[ValidatorHistory]) -> Self {
+    pub fn new(
+        current_epoch: u64,
+        all_validator_histories: &[ValidatorHistory],
+        bam_connected_epochs: HashMap<Pubkey, HashSet<u16>>,
+    ) -> Self {
         // Validator Commission
         let validator_commission_start_epoch = (current_epoch - 30) as u16;
         let validator_commission_end_epoch = (current_epoch - 1) as u16;
@@ -91,8 +102,9 @@ impl BamValidatorEligibility {
         let mev_commission_end_epoch = (current_epoch - 1) as u16;
 
         // Running bam
-        let running_bam_start_epoch = (current_epoch - 3) as u16;
+        let running_bam_start_epoch = current_epoch.saturating_sub(5) as u16;
         let running_bam_end_epoch = (current_epoch - 1) as u16;
+        let min_running_bam_epochs = 3;
 
         // Superminority
         let superminority_start_epoch = (current_epoch - 3) as u16;
@@ -116,11 +128,13 @@ impl BamValidatorEligibility {
             mev_commission_end_epoch,
             running_bam_start_epoch,
             running_bam_end_epoch,
+            min_running_bam_epochs,
             superminority_start_epoch,
             superminority_end_epoch,
             epoch_credits_start_epoch,
             epoch_credits_end_epoch,
             chain_max_credits,
+            bam_connected_epochs,
         }
     }
 
@@ -186,13 +200,26 @@ impl BamValidatorEligibility {
             return Err(IneligibilityReason::InsufficientHistory);
         }
 
-        for (i, _) in (self.running_bam_start_epoch..=self.running_bam_end_epoch).enumerate() {
-            // BAM clients
-            if let Some(client_type) = client_types[i] {
-                if !matches!(ClientType::from_u8(client_type), ClientType::Bam) {
-                    return Err(IneligibilityReason::NotBamClient);
-                }
-            }
+        let bam_capable_epochs = client_types
+            .iter()
+            .flatten()
+            .filter(|client_type| ClientType::from_u8(**client_type).is_bam_capable())
+            .count();
+        if bam_capable_epochs < self.min_running_bam_epochs {
+            return Err(IneligibilityReason::NotBamClient);
+        }
+
+        let bam_connected_epochs = self
+            .bam_connected_epochs
+            .get(&validator_history.vote_account)
+            .map(|epochs| {
+                (self.running_bam_start_epoch..=self.running_bam_end_epoch)
+                    .filter(|epoch| epochs.contains(epoch))
+                    .count()
+            })
+            .unwrap_or_default();
+        if bam_connected_epochs < self.min_running_bam_epochs {
+            return Err(IneligibilityReason::NotBamConnected);
         }
 
         for (i, epoch) in (self.validator_commission_start_epoch
@@ -336,6 +363,17 @@ mod tests {
         history
     }
 
+    fn create_recent_bam_connected_epochs(
+        current_epoch: u64,
+        vote_account: Pubkey,
+    ) -> HashMap<Pubkey, HashSet<u16>> {
+        let start_epoch = current_epoch.saturating_sub(5) as u16;
+        let end_epoch = current_epoch.saturating_sub(1) as u16;
+        let mut bam_connected_epochs = HashMap::new();
+        bam_connected_epochs.insert(vote_account, (start_epoch..=end_epoch).collect());
+        bam_connected_epochs
+    }
+
     #[test]
     fn test_eligible_validator_passes() {
         let blacklist_validators = vec![];
@@ -348,7 +386,11 @@ mod tests {
         }
         let vh1 = create_validator_history(entries);
 
-        let checker = BamValidatorEligibility::new(30, &[vh1.clone()]);
+        let checker = BamValidatorEligibility::new(
+            30,
+            &[vh1.clone()],
+            create_recent_bam_connected_epochs(30, vh1.vote_account),
+        );
 
         assert!(checker
             .check_eligibility(&blacklist_validators, &steward_config, &vh1)
@@ -360,17 +402,68 @@ mod tests {
         let blacklist_validators = vec![];
         let steward_config = create_steward_config();
         let vh = create_validator_history(vec![
+            create_entry(96, 2, 0, 10, 0, 10000), // Firedancer
             create_entry(97, 2, 0, 10, 0, 10000), // Firedancer
-            create_entry(98, 6, 5, 10, 0, 10000),
-            create_entry(99, 6, 0, 10, 0, 10000),
-            create_entry(100, 6, 0, 10, 0, 10000),
+            create_entry(98, 6, 0, 10, 0, 10000),
+            create_entry(99, 1, 0, 10, 0, 10000), // JitoLabs is BAM-capable
+            create_entry(100, 1, 0, 10, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(100, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
             Err(IneligibilityReason::NotBamClient)
+        );
+    }
+
+    #[test]
+    fn test_jito_labs_client_passes() {
+        let blacklist_validators = vec![];
+        let steward_config = create_steward_config();
+        let vh = create_validator_history(vec![
+            create_entry(96, 1, 0, 10, 0, 10000),
+            create_entry(97, 1, 0, 10, 0, 10000),
+            create_entry(98, 1, 0, 10, 0, 10000),
+            create_entry(99, 1, 0, 10, 0, 10000),
+            create_entry(100, 1, 0, 10, 0, 10000),
+        ]);
+
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(100, vh.vote_account),
+        );
+
+        assert!(checker
+            .check_eligibility(&blacklist_validators, &steward_config, &vh)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_requires_three_of_last_five_bam_connected_epochs() {
+        let blacklist_validators = vec![];
+        let steward_config = create_steward_config();
+        let vh = create_validator_history(vec![
+            create_entry(95, 1, 0, 10, 0, 10000),
+            create_entry(96, 1, 0, 10, 0, 10000),
+            create_entry(97, 1, 0, 10, 0, 10000),
+            create_entry(98, 6, 0, 10, 0, 10000),
+            create_entry(99, 6, 0, 10, 0, 10000),
+            create_entry(100, 6, 0, 10, 0, 10000),
+        ]);
+        let mut bam_connected_epochs = HashMap::new();
+        bam_connected_epochs.insert(vh.vote_account, HashSet::from([96_u16, 99_u16]));
+
+        let checker = BamValidatorEligibility::new(100, &[vh.clone()], bam_connected_epochs);
+
+        assert_eq!(
+            checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
+            Err(IneligibilityReason::NotBamConnected)
         );
     }
 
@@ -388,7 +481,11 @@ mod tests {
 
         let vh = create_validator_history(entries);
 
-        let checker = BamValidatorEligibility::new(31, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            31,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(31, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
@@ -413,7 +510,11 @@ mod tests {
 
         let vh = create_validator_history(entries);
 
-        let checker = BamValidatorEligibility::new(31, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            31,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(31, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
@@ -435,7 +536,11 @@ mod tests {
             create_entry(100, 6, 0, 10, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(100, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
@@ -461,7 +566,11 @@ mod tests {
             create_entry(100, 6, 0, 10, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh_good, vh_bad.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh_good, vh_bad.clone()],
+            create_recent_bam_connected_epochs(100, vh_bad.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh_bad),
@@ -483,7 +592,11 @@ mod tests {
             create_entry(100, 6, 0, 10, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(100, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
@@ -509,7 +622,11 @@ mod tests {
             create_entry(100, 6, 0, 10, 0, 9700),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh_max, vh_97.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh_max, vh_97.clone()],
+            create_recent_bam_connected_epochs(100, vh_97.vote_account),
+        );
 
         assert!(checker
             .check_eligibility(&blacklist_validators, &steward_config, &vh_97)
@@ -536,7 +653,11 @@ mod tests {
             create_entry(100, 6, 0, 1100, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh_10.clone(), vh_11.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh_10.clone(), vh_11.clone()],
+            create_recent_bam_connected_epochs(100, vh_10.vote_account),
+        );
 
         assert!(checker
             .check_eligibility(&blacklist_validators, &steward_config, &vh_10)
@@ -562,7 +683,11 @@ mod tests {
             create_entry(100, 6, 0, 10, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(100, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),
@@ -583,7 +708,11 @@ mod tests {
             create_entry(100, 6, 0, 10, 0, 10000),
         ]);
 
-        let checker = BamValidatorEligibility::new(100, &[vh.clone()]);
+        let checker = BamValidatorEligibility::new(
+            100,
+            &[vh.clone()],
+            create_recent_bam_connected_epochs(100, vh.vote_account),
+        );
 
         assert_eq!(
             checker.check_eligibility(&blacklist_validators, &steward_config, &vh),

--- a/bam-writer-service/src/lib.rs
+++ b/bam-writer-service/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::Arc,
+};
 
 use anyhow::anyhow;
 use bam_api_client::{client::BamApiClient, types::ValidatorsResponse};
@@ -172,6 +176,37 @@ impl BamWriterService {
         }
     }
 
+    async fn get_recent_bam_connected_epochs(
+        &self,
+        current_epoch: u64,
+    ) -> anyhow::Result<HashMap<Pubkey, HashSet<u16>>> {
+        let mut bam_connected_epochs: HashMap<Pubkey, HashSet<u16>> = HashMap::new();
+
+        for epoch in current_epoch.saturating_sub(5)..current_epoch {
+            let validators = self.bam_validators_store.find(epoch).await?;
+            for validator in validators {
+                let vote_account = match Pubkey::from_str(&validator.get_vote_account()) {
+                    Ok(vote_account) => vote_account,
+                    Err(err) => {
+                        log::warn!(
+                            "Skipping historical BAM validator with invalid vote account {} at epoch {}: {}",
+                            validator.get_vote_account(),
+                            epoch,
+                            err
+                        );
+                        continue;
+                    }
+                };
+                bam_connected_epochs
+                    .entry(vote_account)
+                    .or_default()
+                    .insert(epoch as u16);
+            }
+        }
+
+        Ok(bam_connected_epochs)
+    }
+
     /// Run [`BamWriterService`]
     pub async fn run(&self) -> anyhow::Result<()> {
         let epoch_info = self.rpc_client.get_epoch_info().await?;
@@ -268,7 +303,9 @@ impl BamWriterService {
             )
             .await?;
 
-            let eligibility_checker = BamValidatorEligibility::new(epoch, &validator_histories);
+            let bam_connected_epochs = self.get_recent_bam_connected_epochs(epoch).await?;
+            let eligibility_checker =
+                BamValidatorEligibility::new(epoch, &validator_histories, bam_connected_epochs);
             let mut validators: Vec<BamValidator> = Vec::new();
 
             for validator_history in validator_histories.iter() {
@@ -301,6 +338,9 @@ impl BamWriterService {
                         Err(reason) => {
                             let reason_string = match reason {
                                 IneligibilityReason::NotBamClient => "NotBamClient".to_string(),
+                                IneligibilityReason::NotBamConnected => {
+                                    "NotBamConnected".to_string()
+                                }
                                 IneligibilityReason::NonZeroCommission { epoch, commission } => {
                                     format!("NonZeroCommission: {} in epoch {}", commission, epoch)
                                 }

--- a/bam-writer-service/src/lib.rs
+++ b/bam-writer-service/src/lib.rs
@@ -25,7 +25,9 @@ use stakenet_sdk::{
 
 use crate::{
     bam_delegation_criteria::BamDelegationCriteria,
-    bam_validator_eligibility::{BamValidatorEligibility, IneligibilityReason},
+    bam_validator_eligibility::{
+        BamValidatorEligibility, IneligibilityReason, RUNNING_BAM_LOOKBACK_EPOCHS,
+    },
 };
 
 mod bam_delegation_criteria;
@@ -182,7 +184,7 @@ impl BamWriterService {
     ) -> anyhow::Result<HashMap<Pubkey, HashSet<u16>>> {
         let mut bam_connected_epochs: HashMap<Pubkey, HashSet<u16>> = HashMap::new();
 
-        for epoch in current_epoch.saturating_sub(5)..current_epoch {
+        for epoch in current_epoch.saturating_sub(RUNNING_BAM_LOOKBACK_EPOCHS)..current_epoch {
             let validators = self.bam_validators_store.find(epoch).await?;
             for validator in validators {
                 let vote_account = match Pubkey::from_str(&validator.get_vote_account()) {

--- a/core/src/client_type.rs
+++ b/core/src/client_type.rs
@@ -46,6 +46,11 @@ impl ClientType {
         }
     }
 
+    /// Returns true when the client can run BAM transaction forwarding.
+    pub fn is_bam_capable(&self) -> bool {
+        matches!(self, ClientType::JitoLabs | ClientType::Bam)
+    }
+
     /// Returns the string representation of the client type.
     ///
     /// # Examples


### PR DESCRIPTION
#### Problem

- Since the client change, we might unfairly punishing validators based on when exactly we record values if they’re temporarily disconnected from BAM

#### Solution

- Loose Criteria
    - Connected to BAM for 3 out of the last 5 epochs
    - They were running either clientId: JitoLabs or BAM