### PR TITLE
Kobe Writer Service: Improve tracking bam connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,6 +3258,7 @@ dependencies = [
  "kobe-core",
  "log",
  "mongodb",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "sentry",
  "sentry-log",

--- a/core/src/db_models/validators.rs
+++ b/core/src/db_models/validators.rs
@@ -46,6 +46,15 @@ pub struct Validator {
 
     /// Whether or not running BAM client
     pub running_bam: Option<bool>,
+
+    /// Number of 10-minute snapshots this epoch where the validator was observed connected to BAM
+    #[serde(default)]
+    pub bam_connected_count: u32,
+
+    /// Total number of 10-minute snapshots taken this epoch
+    #[serde(default)]
+    pub bam_total_snapshots: u32,
+
     pub software_version: Option<String>,
     pub software_version_score: Option<i64>,
     pub skipped_slot_percent: Option<String>,
@@ -100,6 +109,8 @@ impl Validator {
             root_distance_score: validators_app_entry.root_distance_score,
             running_jito: on_chain_data.running_jito,
             running_bam: Some(on_chain_data.running_bam),
+            bam_connected_count: 0,
+            bam_total_snapshots: 0,
             software_version: validators_app_entry.software_version.clone(),
             software_version_score: validators_app_entry.software_version_score,
             skipped_slot_percent: validators_app_entry.skipped_slot_percent.clone(),
@@ -129,6 +140,16 @@ impl Validator {
         self.target_pool_active_lamports
             .checked_add(self.target_pool_transient_lamports)
             .unwrap()
+    }
+
+    /// Fraction of 10-minute snapshots this epoch where the validator was connected to BAM.
+    /// Returns `None` if no snapshots have been recorded yet.
+    pub fn bam_connection_rate(&self) -> Option<f64> {
+        if self.bam_total_snapshots == 0 {
+            None
+        } else {
+            Some(self.bam_connected_count as f64 / self.bam_total_snapshots as f64)
+        }
     }
 }
 

--- a/core/src/db_models/validators.rs
+++ b/core/src/db_models/validators.rs
@@ -114,7 +114,7 @@ impl Validator {
             published_information_score: validators_app_entry.published_information_score,
             root_distance_score: validators_app_entry.root_distance_score,
             running_jito: on_chain_data.running_jito,
-            running_bam: on_chain_data.running_bam,
+            running_bam: None,
             bam_connected_count: 0,
             bam_total_snapshots: 0,
             software_version: validators_app_entry.software_version.clone(),

--- a/core/src/db_models/validators.rs
+++ b/core/src/db_models/validators.rs
@@ -45,17 +45,19 @@ pub struct Validator {
     /// Whether or not running Jito client
     pub running_jito: bool,
 
-    /// BAM API-observed connection status for this snapshot.
+    /// BAM API-observed connection status as of the most recent BAM snapshot.
     /// `Some(true)` = API queried and validator is connected.
     /// `Some(false)` = API queried but validator is not connected.
-    /// `None` = BAM API not configured or returned an empty set; drives `bam_connected_count` / `bam_total_snapshots`.
+    /// `None` = no BAM snapshot recorded yet this epoch (BAM API not configured or unreachable).
+    ///
+    /// Owned by the writer's BAM snapshot job, not the validator write.
     pub running_bam: Option<bool>,
 
-    /// Number of 10-minute snapshots this epoch where the validator was observed connected to BAM
+    /// Number of BAM snapshots this epoch where the validator was observed connected to BAM
     #[serde(default)]
     pub bam_connected_count: u32,
 
-    /// Total number of 10-minute snapshots taken this epoch
+    /// Total number of BAM snapshots taken this epoch (the connection-rate denominator)
     #[serde(default)]
     pub bam_total_snapshots: u32,
 
@@ -146,7 +148,7 @@ impl Validator {
             .unwrap()
     }
 
-    /// Fraction of 10-minute snapshots this epoch where the validator was connected to BAM.
+    /// Fraction of BAM snapshots this epoch where the validator was connected to BAM.
     /// Returns `None` if no snapshots have been recorded yet.
     pub fn bam_connection_rate(&self) -> Option<f64> {
         if self.bam_total_snapshots == 0 {

--- a/core/src/db_models/validators.rs
+++ b/core/src/db_models/validators.rs
@@ -45,12 +45,12 @@ pub struct Validator {
     /// Whether or not running Jito client
     pub running_jito: bool,
 
-    /// BAM API-observed connection status as of the most recent BAM snapshot.
-    /// `Some(true)` = API queried and validator is connected.
-    /// `Some(false)` = API queried but validator is not connected.
-    /// `None` = no BAM snapshot recorded yet this epoch (BAM API not configured or unreachable).
+    /// BAM API-observed connection status as of the most recent BAM snapshot
+    /// `Some(true)` = API queried and validator is connected
+    /// `Some(false)` = API queried but validator is not connected
+    /// `None` = no BAM snapshot recorded yet this epoch (BAM API not configured or unreachable)
     ///
-    /// Owned by the writer's BAM snapshot job, not the validator write.
+    /// Owned by the writer's BAM snapshot job, not the validator write
     pub running_bam: Option<bool>,
 
     /// Number of BAM snapshots this epoch where the validator was observed connected to BAM
@@ -148,8 +148,8 @@ impl Validator {
             .unwrap()
     }
 
-    /// Fraction of BAM snapshots this epoch where the validator was connected to BAM.
-    /// Returns `None` if no snapshots have been recorded yet.
+    /// Fraction of BAM snapshots this epoch where the validator was connected to BAM
+    /// Returns `None` if no snapshots have been recorded yet
     pub fn bam_connection_rate(&self) -> Option<f64> {
         if self.bam_total_snapshots == 0 {
             None

--- a/core/src/db_models/validators.rs
+++ b/core/src/db_models/validators.rs
@@ -41,10 +41,14 @@ pub struct Validator {
     pub name: Option<String>,
     pub published_information_score: Option<i64>,
     pub root_distance_score: Option<i64>,
+
     /// Whether or not running Jito client
     pub running_jito: bool,
 
-    /// Whether or not running BAM client
+    /// BAM API-observed connection status for this snapshot.
+    /// `Some(true)` = API queried and validator is connected.
+    /// `Some(false)` = API queried but validator is not connected.
+    /// `None` = BAM API not configured or returned an empty set; drives `bam_connected_count` / `bam_total_snapshots`.
     pub running_bam: Option<bool>,
 
     /// Number of 10-minute snapshots this epoch where the validator was observed connected to BAM
@@ -108,7 +112,7 @@ impl Validator {
             published_information_score: validators_app_entry.published_information_score,
             root_distance_score: validators_app_entry.root_distance_score,
             running_jito: on_chain_data.running_jito,
-            running_bam: Some(on_chain_data.running_bam),
+            running_bam: on_chain_data.running_bam,
             bam_connected_count: 0,
             bam_total_snapshots: 0,
             software_version: validators_app_entry.software_version.clone(),

--- a/core/src/fetcher.rs
+++ b/core/src/fetcher.rs
@@ -57,8 +57,11 @@ pub struct ChainData {
     /// Whether or not running Jito client
     pub running_jito: bool,
 
-    /// Whether or not running BAM client
-    pub running_bam: bool,
+    /// BAM API-observed connection status.
+    /// `Some(true)` = API queried and validator is in the response.
+    /// `Some(false)` = API queried but validator is not in the response.
+    /// `None` = BAM API not configured or returned an empty set; connection unknown.
+    pub running_bam: Option<bool>,
 
     pub vote_credit_proportion: f64,
     pub stake_info: Option<ValidatorStakeInfo>,
@@ -127,8 +130,8 @@ pub fn get_priority_fee_distribution_program_id() -> solana_pubkey::Pubkey {
 ///
 /// ## BAM Client Detection
 ///
-/// - If BAM validator set exists and not empty: check if validator identity is in the set
-/// - Otherwise: fall back to client_type check from validator history
+/// Returns `Some(true/false)` when the BAM API was queried (non-empty response), or `None`
+/// when the BAM API is not configured or returned an empty set.
 pub async fn fetch_chain_data(
     validators: &[ValidatorsAppResponseEntry],
     bam_validator_set: HashSet<String>,
@@ -185,9 +188,15 @@ pub async fn fetch_chain_data(
             .map(|entry| ClientType::from_u8(entry.client_type));
         let is_jito_client = matches!(client_type, Some(ClientType::JitoLabs));
 
-        let running_bam = match (&v.account, bam_validator_set.is_empty()) {
-            (Some(identity), false) => bam_validator_set.contains(identity.as_str()),
-            _ => false,
+        let running_bam = if bam_validator_set.is_empty() {
+            None
+        } else {
+            Some(
+                v.account
+                    .as_deref()
+                    .map(|id| bam_validator_set.contains(id))
+                    .unwrap_or(false),
+            )
         };
         let running_jito = has_tip_account || is_jito_client;
 

--- a/core/src/fetcher.rs
+++ b/core/src/fetcher.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-    sync::Arc,
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use anchor_lang::AccountDeserialize;
 use jito_priority_fee_distribution::state::PriorityFeeDistributionAccount;
@@ -56,12 +52,6 @@ pub struct ChainData {
 
     /// Whether or not running Jito client
     pub running_jito: bool,
-
-    /// BAM API-observed connection status.
-    /// `Some(true)` = API queried and validator is in the response.
-    /// `Some(false)` = API queried but validator is not in the response.
-    /// `None` = BAM API not configured or returned an empty set; connection unknown.
-    pub running_bam: Option<bool>,
 
     pub vote_credit_proportion: f64,
     pub stake_info: Option<ValidatorStakeInfo>,
@@ -134,7 +124,6 @@ pub fn get_priority_fee_distribution_program_id() -> solana_pubkey::Pubkey {
 /// when the BAM API is not configured or returned an empty set.
 pub async fn fetch_chain_data(
     validators: &[ValidatorsAppResponseEntry],
-    bam_validator_set: HashSet<String>,
     rpc_client: Arc<RpcClient>,
     cluster: &Cluster,
     epoch: u64,
@@ -188,16 +177,6 @@ pub async fn fetch_chain_data(
             .map(|entry| ClientType::from_u8(entry.client_type));
         let is_jito_client = matches!(client_type, Some(ClientType::JitoLabs));
 
-        let running_bam = if bam_validator_set.is_empty() {
-            None
-        } else {
-            Some(
-                v.account
-                    .as_deref()
-                    .map(|id| bam_validator_set.contains(id))
-                    .unwrap_or(false),
-            )
-        };
         let running_jito = has_tip_account || is_jito_client;
 
         let (mev_commission_bps, mev_revenue_lamports) =
@@ -252,7 +231,6 @@ pub async fn fetch_chain_data(
             mev_commission_bps,
             mev_revenue_lamports,
             running_jito,
-            running_bam,
             vote_credit_proportion,
             stake_info,
             total_staked_lamports,

--- a/core/src/fetcher.rs
+++ b/core/src/fetcher.rs
@@ -117,11 +117,6 @@ pub fn get_priority_fee_distribution_program_id() -> solana_pubkey::Pubkey {
 /// 1. **Tip account method**: Checks if validator has tip distribution account
 /// 2. **Validator-History method**: Checks validator history for Jito client type
 /// 3. **Combined detection**: Detect `running_jito` = (`has_tip_account || is_jito_client`)
-///
-/// ## BAM Client Detection
-///
-/// Returns `Some(true/false)` when the BAM API was queried (non-empty response), or `None`
-/// when the BAM API is not configured or returned an empty set.
 pub async fn fetch_chain_data(
     validators: &[ValidatorsAppResponseEntry],
     rpc_client: Arc<RpcClient>,

--- a/core/src/fetcher.rs
+++ b/core/src/fetcher.rs
@@ -185,12 +185,9 @@ pub async fn fetch_chain_data(
             .map(|entry| ClientType::from_u8(entry.client_type));
         let is_jito_client = matches!(client_type, Some(ClientType::JitoLabs));
 
-        let is_bam_client = match (&v.account, bam_validator_set.is_empty()) {
+        let running_bam = match (&v.account, bam_validator_set.is_empty()) {
             (Some(identity), false) => bam_validator_set.contains(identity.as_str()),
-            _ => matches!(
-                client_type,
-                Some(ClientType::Bam) | Some(ClientType::FireBam)
-            ),
+            _ => false,
         };
         let running_jito = has_tip_account || is_jito_client;
 
@@ -246,7 +243,7 @@ pub async fn fetch_chain_data(
             mev_commission_bps,
             mev_revenue_lamports,
             running_jito,
-            running_bam: is_bam_client,
+            running_bam,
             vote_credit_proportion,
             stake_info,
             total_staked_lamports,

--- a/writer-service/Cargo.toml
+++ b/writer-service/Cargo.toml
@@ -23,6 +23,7 @@ jito-tip-distribution = { workspace = true }
 kobe-core = { workspace = true }
 log = { workspace = true }
 mongodb = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
 sentry = { workspace = true }
 sentry-log = { workspace = true }

--- a/writer-service/Cargo.toml
+++ b/writer-service/Cargo.toml
@@ -23,7 +23,7 @@ jito-tip-distribution = { workspace = true }
 kobe-core = { workspace = true }
 log = { workspace = true }
 mongodb = { workspace = true }
-rand.worksapce = true
+rand.workspace = true
 reqwest = { workspace = true }
 sentry = { workspace = true }
 sentry-log = { workspace = true }

--- a/writer-service/Cargo.toml
+++ b/writer-service/Cargo.toml
@@ -23,7 +23,7 @@ jito-tip-distribution = { workspace = true }
 kobe-core = { workspace = true }
 log = { workspace = true }
 mongodb = { workspace = true }
-rand = { workspace = true }
+rand.worksapce = true
 reqwest = { workspace = true }
 sentry = { workspace = true }
 sentry-log = { workspace = true }

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -110,10 +110,13 @@ pub async fn upsert_to_db(
 
 /// Record one BAM connection snapshot for the current epoch.
 ///
-/// Runs on its own cadence, decoupled from the validator write. `connected` is the set of
-/// validator *identity* pubkeys the BAM API reports as connected for this snapshot. When it
-/// is empty — BAM API not configured, or it returned nothing / was unreachable — the snapshot
-/// is skipped entirely so a transient outage cannot drive the connection rate toward 0.
+/// Runs on its own cadence, decoupled from the validator write. `connected` carries the BAM
+/// API result: `None` means the API was not queried (not configured), so the snapshot is
+/// skipped entirely and the denominator is left alone. `Some(set)` means the API was queried
+/// successfully — the snapshot is recorded even when the set is empty, because a valid
+/// zero-connected response is a real observation, not a reason to bias the denominator.
+/// (Query *failures* never reach here: they surface as an `Err` from `fetch_bam_connected_set`
+/// and the caller skips the snapshot.)
 ///
 /// For every validator with a document this epoch we bump `bam_total_snapshots` (the
 /// denominator) and default `running_bam` to `false`; validators in `connected` then get
@@ -122,12 +125,12 @@ pub async fn upsert_to_db(
 pub async fn write_bam_snapshot(
     collection: &Collection<Validator>,
     epoch: u64,
-    connected: &HashSet<String>,
+    connected: Option<&HashSet<String>>,
 ) -> Result<()> {
-    if connected.is_empty() {
-        info!("BAM connected set is empty; skipping BAM snapshot for epoch {epoch}");
+    let Some(connected) = connected else {
+        info!("BAM API not configured; skipping BAM snapshot for epoch {epoch}");
         return Ok(());
-    }
+    };
 
     let start = Instant::now();
 
@@ -282,7 +285,7 @@ pub async fn write_bam_snapshot_info(
 ) -> Result<()> {
     let connected = stake_pool_manager.fetch_bam_connected_set().await?;
     let collection = db.collection::<Validator>(VALIDATOR_COLLECTION_NAME);
-    write_bam_snapshot(&collection, epoch, &connected).await
+    write_bam_snapshot(&collection, epoch, connected.as_ref()).await
 }
 
 pub async fn setup_mongo_client(uri: &str) -> Result<MongodbClient> {

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration as CoreDuration, Instant};
+use std::{
+    collections::HashSet,
+    time::{Duration as CoreDuration, Instant},
+};
 
 use backoff::{future::retry, ExponentialBackoff};
 use kobe_core::{
@@ -11,7 +14,7 @@ use kobe_core::{
 };
 use log::{error, info, warn};
 use mongodb::{
-    bson::{self, doc},
+    bson::{self, doc, Bson},
     options::{ClientOptions, UpdateOptions},
     Client as MongodbClient, Collection, Database,
 };
@@ -41,13 +44,14 @@ where
     Ok(())
 }
 
-/// Upsert validators for the current epoch.
+/// Upsert validator metadata for the current epoch.
 ///
-/// BAM connection counters (`bam_total_snapshots` / `bam_connected_count`) are only
-/// incremented when `running_bam` is `Some` — i.e. the BAM API was actually queried this
-/// run. When the API is not configured or returns an empty set `running_bam` is `None`,
-/// and skipping the increment prevents a transient outage from driving the connection
-/// rate toward 0 spuriously.
+/// This writes validator data only. The BAM fields — `running_bam` and the connection
+/// counters (`bam_total_snapshots` / `bam_connected_count`) — are owned by the separate BAM
+/// snapshot job ([`write_bam_snapshot`]), which runs on its own (coarser) cadence. They are
+/// therefore excluded from `$set` so a validator write never clobbers them, and seeded via
+/// `$setOnInsert` so the fields exist as soon as a new epoch document is created (epoch
+/// rollover) rather than being absent until the first snapshot lands.
 pub async fn upsert_to_db(
     collection: &Collection<Validator>,
     items: &[Validator],
@@ -67,21 +71,10 @@ pub async fn upsert_to_db(
 
         for item in chunk {
             let mut set_doc = bson::to_document(item).map_err(|e| AppError::from(e.to_string()))?;
-            // Remove the counter fields from $set so they are only touched via $inc
+            // The BAM snapshot job owns these fields; never overwrite them from a validator write.
+            set_doc.remove("running_bam");
             set_doc.remove("bam_connected_count");
             set_doc.remove("bam_total_snapshots");
-
-            let mut update_doc = doc! { "$set": set_doc };
-
-            if let Some(connected) = item.running_bam {
-                update_doc.insert(
-                    "$inc",
-                    doc! {
-                        "bam_total_snapshots": 1_i32,
-                        "bam_connected_count": i32::from(connected)
-                    },
-                );
-            }
 
             collection
                 .update_one(
@@ -89,7 +82,14 @@ pub async fn upsert_to_db(
                         "epoch": epoch as u32,
                         "vote_account": &item.vote_account
                     },
-                    update_doc,
+                    doc! {
+                        "$set": set_doc,
+                        "$setOnInsert": {
+                            "running_bam": Bson::Null,
+                            "bam_connected_count": 0_i32,
+                            "bam_total_snapshots": 0_i32
+                        },
+                    },
                     update_options.clone(),
                 )
                 .await?;
@@ -102,6 +102,78 @@ pub async fn upsert_to_db(
     info!(
         "done upserting {} items to db, took {}ms",
         items.len(),
+        start.elapsed().as_millis()
+    );
+
+    Ok(())
+}
+
+/// Record one BAM connection snapshot for the current epoch.
+///
+/// Runs on its own cadence, decoupled from the validator write. `connected` is the set of
+/// validator *identity* pubkeys the BAM API reports as connected for this snapshot. When it
+/// is empty — BAM API not configured, or it returned nothing / was unreachable — the snapshot
+/// is skipped entirely so a transient outage cannot drive the connection rate toward 0.
+///
+/// For every validator with a document this epoch we bump `bam_total_snapshots` (the
+/// denominator) and default `running_bam` to `false`; validators in `connected` then get
+/// `bam_connected_count` bumped and `running_bam` set to `true`. Validators without a document
+/// yet this epoch (not written by the validator job) are simply skipped this snapshot.
+pub async fn write_bam_snapshot(
+    collection: &Collection<Validator>,
+    epoch: u64,
+    connected: &HashSet<String>,
+) -> Result<()> {
+    if connected.is_empty() {
+        info!("BAM connected set is empty; skipping BAM snapshot for epoch {epoch}");
+        return Ok(());
+    }
+
+    let start = Instant::now();
+
+    // Denominator: every validator observed this epoch counts as one snapshot and defaults to
+    // not-connected until the numerator pass below proves otherwise.
+    collection
+        .update_many(
+            doc! { "epoch": epoch as u32 },
+            doc! {
+                "$inc": { "bam_total_snapshots": 1_i32 },
+                "$set": { "running_bam": false },
+            },
+            None,
+        )
+        .await?;
+
+    // Numerator: validators the BAM API reports as connected this snapshot. The connected set
+    // can be large, so chunk the `$in` filter into batches rather than issuing one oversized
+    // query, mirroring the batching `upsert_to_db` uses.
+    let batch_size = 100;
+    let connected_ids: Vec<&str> = connected.iter().map(String::as_str).collect();
+    let mut marked_connected = 0_u64;
+
+    for chunk in connected_ids.chunks(batch_size) {
+        let result = collection
+            .update_many(
+                doc! {
+                    "epoch": epoch as u32,
+                    "identity_account": { "$in": chunk }
+                },
+                doc! {
+                    "$inc": { "bam_connected_count": 1_i32 },
+                    "$set": { "running_bam": true },
+                },
+                None,
+            )
+            .await?;
+        marked_connected += result.modified_count;
+
+        // Small delay between batches to avoid overwhelming the server
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+
+    info!(
+        "BAM snapshot for epoch {epoch}: marked {marked_connected} connected (BAM reported {}), took {}ms",
+        connected.len(),
         start.elapsed().as_millis()
     );
 
@@ -199,6 +271,18 @@ pub async fn write_validator_info(
             e
         })?;
     upsert_to_db(&collection, &validators, epoch).await
+}
+
+/// Query the BAM API for the currently-connected validator set and record one snapshot for
+/// `epoch`. See [`write_bam_snapshot`] for the snapshot semantics.
+pub async fn write_bam_snapshot_info(
+    db: &Database,
+    stake_pool_manager: &StakePoolManager,
+    epoch: u64,
+) -> Result<()> {
+    let connected = stake_pool_manager.fetch_bam_connected_set().await?;
+    let collection = db.collection::<Validator>(VALIDATOR_COLLECTION_NAME);
+    write_bam_snapshot(&collection, epoch, &connected).await
 }
 
 pub async fn setup_mongo_client(uri: &str) -> Result<MongodbClient> {

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -44,10 +44,10 @@ where
     Ok(())
 }
 
-/// Upsert validator metadata for the current epoch.
+/// Upsert validator metadata for the current epoch
 ///
-/// This writes validator data only. The BAM fields — `running_bam` and the connection
-/// counters (`bam_total_snapshots` / `bam_connected_count`) — are owned by the separate BAM
+/// This writes validator data only. The BAM fields - `running_bam` and the connection
+/// counters (`bam_total_snapshots` / `bam_connected_count`) - are owned by the separate BAM
 /// snapshot job ([`write_bam_snapshot`]), which runs on its own (coarser) cadence. They are
 /// therefore excluded from `$set` so a validator write never clobbers them, and seeded via
 /// `$setOnInsert` so the fields exist as soon as a new epoch document is created (epoch
@@ -71,7 +71,6 @@ pub async fn upsert_to_db(
 
         for item in chunk {
             let mut set_doc = bson::to_document(item).map_err(|e| AppError::from(e.to_string()))?;
-            // The BAM snapshot job owns these fields; never overwrite them from a validator write.
             set_doc.remove("running_bam");
             set_doc.remove("bam_connected_count");
             set_doc.remove("bam_total_snapshots");
@@ -108,12 +107,12 @@ pub async fn upsert_to_db(
     Ok(())
 }
 
-/// Record one BAM connection snapshot for the current epoch.
+/// Record one BAM connection snapshot for the current epoch
 ///
 /// Runs on its own cadence, decoupled from the validator write. `connected` carries the BAM
 /// API result: `None` means the API was not queried (not configured), so the snapshot is
 /// skipped entirely and the denominator is left alone. `Some(set)` means the API was queried
-/// successfully — the snapshot is recorded even when the set is empty, because a valid
+/// successfully - the snapshot is recorded even when the set is empty, because a valid
 /// zero-connected response is a real observation, not a reason to bias the denominator.
 /// (Query *failures* never reach here: they surface as an `Err` from `fetch_bam_connected_set`
 /// and the caller skips the snapshot.)

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -11,8 +11,8 @@ use kobe_core::{
 };
 use log::{error, info, warn};
 use mongodb::{
-    bson::doc,
-    options::{ClientOptions, ReplaceOptions},
+    bson::{self, doc},
+    options::{ClientOptions, UpdateOptions},
     Client as MongodbClient, Collection, Database,
 };
 use reqwest::Client as ReqwestClient;
@@ -21,7 +21,7 @@ use solana_program::pubkey::Pubkey;
 
 use crate::{
     google_storage, merkle_tree_parser,
-    result::Result,
+    result::{AppError, Result},
     stake_pool_manager::StakePoolManager,
     tip_distributor_sdk::{GeneratedMerkleTreeCollection, StakeMetaCollection},
 };
@@ -49,8 +49,7 @@ pub async fn upsert_to_db(
     let start = Instant::now();
     let batch_size = 100;
 
-    let mut replace_options = ReplaceOptions::default();
-    replace_options.upsert = Some(true);
+    let update_options = UpdateOptions::builder().upsert(true).build();
 
     for (i, chunk) in items.chunks(batch_size).enumerate() {
         info!(
@@ -60,14 +59,32 @@ pub async fn upsert_to_db(
         );
 
         for item in chunk {
+            let mut set_doc = bson::to_document(item)
+                .map_err(|e| AppError::from(e.to_string()))?;
+            // Remove the counter fields from $set so they are only touched via $inc
+            set_doc.remove("bam_connected_count");
+            set_doc.remove("bam_total_snapshots");
+
+            let bam_inc = if item.running_bam.unwrap_or(false) {
+                1_i32
+            } else {
+                0_i32
+            };
+
             collection
-                .replace_one(
+                .update_one(
                     doc! {
                         "epoch": epoch as u32,
                         "vote_account": &item.vote_account
                     },
-                    item,
-                    replace_options.clone(),
+                    doc! {
+                        "$set": set_doc,
+                        "$inc": {
+                            "bam_total_snapshots": 1_i32,
+                            "bam_connected_count": bam_inc
+                        }
+                    },
+                    update_options.clone(),
                 )
                 .await?;
         }

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -41,6 +41,13 @@ where
     Ok(())
 }
 
+/// Upsert validators for the current epoch.
+///
+/// BAM connection counters (`bam_total_snapshots` / `bam_connected_count`) are only
+/// incremented when `running_bam` is `Some` — i.e. the BAM API was actually queried this
+/// run. When the API is not configured or returns an empty set `running_bam` is `None`,
+/// and skipping the increment prevents a transient outage from driving the connection
+/// rate toward 0 spuriously.
 pub async fn upsert_to_db(
     collection: &Collection<Validator>,
     items: &[Validator],
@@ -64,11 +71,17 @@ pub async fn upsert_to_db(
             set_doc.remove("bam_connected_count");
             set_doc.remove("bam_total_snapshots");
 
-            let bam_inc = if item.running_bam.unwrap_or(false) {
-                1_i32
-            } else {
-                0_i32
-            };
+            let mut update_doc = doc! { "$set": set_doc };
+
+            if let Some(connected) = item.running_bam {
+                update_doc.insert(
+                    "$inc",
+                    doc! {
+                        "bam_total_snapshots": 1_i32,
+                        "bam_connected_count": i32::from(connected)
+                    },
+                );
+            }
 
             collection
                 .update_one(
@@ -76,13 +89,7 @@ pub async fn upsert_to_db(
                         "epoch": epoch as u32,
                         "vote_account": &item.vote_account
                     },
-                    doc! {
-                        "$set": set_doc,
-                        "$inc": {
-                            "bam_total_snapshots": 1_i32,
-                            "bam_connected_count": bam_inc
-                        }
-                    },
+                    update_doc,
                     update_options.clone(),
                 )
                 .await?;

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -59,8 +59,7 @@ pub async fn upsert_to_db(
         );
 
         for item in chunk {
-            let mut set_doc = bson::to_document(item)
-                .map_err(|e| AppError::from(e.to_string()))?;
+            let mut set_doc = bson::to_document(item).map_err(|e| AppError::from(e.to_string()))?;
             // Remove the counter fields from $set so they are only touched via $inc
             set_doc.remove("bam_connected_count");
             set_doc.remove("bam_total_snapshots");

--- a/writer-service/src/db.rs
+++ b/writer-service/src/db.rs
@@ -118,10 +118,12 @@ pub async fn upsert_to_db(
 /// (Query *failures* never reach here: they surface as an `Err` from `fetch_bam_connected_set`
 /// and the caller skips the snapshot.)
 ///
-/// For every validator with a document this epoch we bump `bam_total_snapshots` (the
-/// denominator) and default `running_bam` to `false`; validators in `connected` then get
-/// `bam_connected_count` bumped and `running_bam` set to `true`. Validators without a document
-/// yet this epoch (not written by the validator job) are simply skipped this snapshot.
+/// `bam_total_snapshots` (the denominator) is bumped for every validator with a document this
+/// epoch. `running_bam` (read live by the API) is updated so each document only ever moves
+/// toward its correct new value: connected validators are set `true` and never transiently
+/// flipped to `false`, while validators no longer connected are set `false`. Connected
+/// validators additionally get `bam_connected_count` bumped. Validators without a document yet
+/// this epoch (not written by the validator job) are simply skipped this snapshot.
 pub async fn write_bam_snapshot(
     collection: &Collection<Validator>,
     epoch: u64,
@@ -133,25 +135,31 @@ pub async fn write_bam_snapshot(
     };
 
     let start = Instant::now();
+    let connected_ids: Vec<&str> = connected.iter().map(String::as_str).collect();
 
-    // Denominator: every validator observed this epoch counts as one snapshot and defaults to
-    // not-connected until the numerator pass below proves otherwise.
+    // Denominator: every validator observed this epoch counts as one snapshot
     collection
         .update_many(
             doc! { "epoch": epoch as u32 },
-            doc! {
-                "$inc": { "bam_total_snapshots": 1_i32 },
-                "$set": { "running_bam": false },
-            },
+            doc! { "$inc": { "bam_total_snapshots": 1_i32 } },
             None,
         )
         .await?;
 
-    // Numerator: validators the BAM API reports as connected this snapshot. The connected set
-    // can be large, so chunk the `$in` filter into batches rather than issuing one oversized
-    // query, mirroring the batching `upsert_to_db` uses.
+    // Mark the not-connected validators `false`
+    collection
+        .update_many(
+            doc! {
+                "epoch": epoch as u32,
+                "identity_account": { "$nin": connected_ids.as_slice() }
+            },
+            doc! { "$set": { "running_bam": false } },
+            None,
+        )
+        .await?;
+
+    // Numerator: validators the BAM API reports as connected this snapshot
     let batch_size = 100;
-    let connected_ids: Vec<&str> = connected.iter().map(String::as_str).collect();
     let mut marked_connected = 0_u64;
 
     for chunk in connected_ids.chunks(batch_size) {

--- a/writer-service/src/lib.rs
+++ b/writer-service/src/lib.rs
@@ -15,7 +15,9 @@ use tokio::time::{sleep_until, Instant};
 
 use crate::{
     bam_boost_manager::BamBoostManager,
-    db::{write_mev_claims_info, write_stake_pool_info, write_validator_info},
+    db::{
+        write_bam_snapshot_info, write_mev_claims_info, write_stake_pool_info, write_validator_info,
+    },
     result::Result,
     stake_pool_manager::StakePoolManager,
 };
@@ -131,10 +133,16 @@ impl KobeWriterService {
     ///   into DB
     /// - Collect MEV Claim information from on-chain and GCP server, then update into DB
     ///
+    /// Every 30 min
+    /// - Record one BAM connection snapshot (separate from the validator write so a BAM API
+    ///   outage never blocks validator data, and the snapshot cadence is explicit)
+    ///
     /// Hourly
     /// - Collect stake pool stats from on-chain, then write into DB
     pub async fn run_live_mode(&self) -> Result<()> {
         let mut next_hourly_update = Instant::now();
+        // Do not fire on boot: a restart should delay the next snapshot, never duplicate one.
+        let mut next_bam_snapshot = Instant::now() + Duration::from_secs(1800); // 30 minutes
         info!("Starting live mode with 10-minute epoch processing intervals");
 
         loop {
@@ -142,8 +150,23 @@ impl KobeWriterService {
 
             // Process epoch every 10 minutes
             info!("Processing epoch...");
-            self.process_epoch().await?;
+            let epoch = self.process_epoch().await?;
             info!("Epoch processing completed");
+
+            // Record a BAM connection snapshot every 30 minutes, independent of validator writes.
+            if Instant::now() >= next_bam_snapshot {
+                info!("Recording BAM connection snapshot for epoch {epoch}");
+                match write_bam_snapshot_info(&self.db, &self.stake_pool_manager, epoch).await {
+                    Ok(_) => {
+                        datapoint_info!("bam_snapshot_written", ("success", 1, i64), "cluster" => self.cluster.to_string());
+                    }
+                    Err(e) => {
+                        error!("Writing BAM snapshot failed. Error: {e:?}");
+                        datapoint_info!("bam_snapshot_written", ("success", 0, i64), "cluster" => self.cluster.to_string());
+                    }
+                }
+                next_bam_snapshot = Instant::now() + Duration::from_secs(1800);
+            }
 
             // Check if it's time for the hourly update
             if Instant::now() >= next_hourly_update {
@@ -203,8 +226,11 @@ impl KobeWriterService {
         Ok(())
     }
 
-    /// Process the epoch by writing validator info and MEV claims info to the database
-    async fn process_epoch(&self) -> Result<()> {
+    /// Process the epoch by writing validator info and MEV claims info to the database.
+    ///
+    /// Returns the current epoch so the caller can reuse it (e.g. for the BAM snapshot) without
+    /// a second RPC round-trip.
+    async fn process_epoch(&self) -> Result<u64> {
         let epoch = rpc_utils::retry_get_epoch_info(&self.stake_pool_manager.rpc_client).await?;
 
         match write_validator_info(
@@ -243,6 +269,6 @@ impl KobeWriterService {
             }
         }
 
-        Ok(())
+        Ok(epoch)
     }
 }

--- a/writer-service/src/lib.rs
+++ b/writer-service/src/lib.rs
@@ -6,6 +6,7 @@ use kobe_core::{
 };
 use log::{error, info};
 use mongodb::Database;
+use rand::Rng;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_metrics::datapoint_info;
 use solana_sdk::{commitment_config::CommitmentConfig, pubkey::Pubkey};
@@ -30,6 +31,14 @@ pub mod result;
 pub mod rpc_utils;
 pub mod stake_pool_manager;
 pub mod tip_distributor_sdk;
+
+/// Target spacing between BAM connection snapshots.
+const BAM_SNAPSHOT_BASE_SECS: u64 = 1800; // 30 minutes
+
+/// Maximum random offset applied to each BAM snapshot interval, in either direction. Spreading
+/// the snapshot away from an exact 30-minute cadence makes it harder to predict when a snapshot
+/// is taken (and therefore harder to game the connection-rate metric).
+const BAM_SNAPSHOT_JITTER_SECS: u64 = 300; // +/- 5 minutes
 
 /// Kobe writer service main instance
 pub struct KobeWriterService {
@@ -124,6 +133,16 @@ impl KobeWriterService {
         })
     }
 
+    /// A randomized delay until the next BAM snapshot, uniformly in
+    /// `BAM_SNAPSHOT_BASE_SECS ± BAM_SNAPSHOT_JITTER_SECS`.
+    fn next_bam_snapshot_delay(&self) -> Duration {
+        let secs = rand::thread_rng().gen_range(
+            (BAM_SNAPSHOT_BASE_SECS - BAM_SNAPSHOT_JITTER_SECS)
+                ..=(BAM_SNAPSHOT_BASE_SECS + BAM_SNAPSHOT_JITTER_SECS),
+        );
+        Duration::from_secs(secs)
+    }
+
     /// Run [`KobeWriterService`] in live mode
     ///
     /// In this mode, the service processes:
@@ -141,8 +160,8 @@ impl KobeWriterService {
     /// - Collect stake pool stats from on-chain, then write into DB
     pub async fn run_live_mode(&self) -> Result<()> {
         let mut next_hourly_update = Instant::now();
-        // Do not fire on boot: a restart should delay the next snapshot, never duplicate one.
-        let mut next_bam_snapshot = Instant::now() + Duration::from_secs(1800); // 30 minutes
+        let mut next_bam_snapshot = Instant::now() + self.next_bam_snapshot_delay();
+
         info!("Starting live mode with 10-minute epoch processing intervals");
 
         loop {
@@ -153,7 +172,9 @@ impl KobeWriterService {
             let epoch = self.process_epoch().await?;
             info!("Epoch processing completed");
 
-            // Record a BAM connection snapshot every 30 minutes, independent of validator writes.
+            // Record a BAM connection snapshot roughly every 30 minutes (jittered), independent
+            // of validator writes. Note the check only runs once per ~10-minute loop tick, so
+            // the jitter varies the interval between snapshots rather than giving sub-tick timing.
             if Instant::now() >= next_bam_snapshot {
                 info!("Recording BAM connection snapshot for epoch {epoch}");
                 match write_bam_snapshot_info(&self.db, &self.stake_pool_manager, epoch).await {
@@ -165,7 +186,8 @@ impl KobeWriterService {
                         datapoint_info!("bam_snapshot_written", ("success", 0, i64), "cluster" => self.cluster.to_string());
                     }
                 }
-                next_bam_snapshot = Instant::now() + Duration::from_secs(1800);
+
+                next_bam_snapshot = Instant::now() + self.next_bam_snapshot_delay();
             }
 
             // Check if it's time for the hourly update

--- a/writer-service/src/stake_pool_manager.rs
+++ b/writer-service/src/stake_pool_manager.rs
@@ -73,20 +73,13 @@ impl StakePoolManager {
         })
         .await??;
 
-        let bam_validator_set: HashSet<String> =
-            if let Some(ref bam_api_client) = self.bam_api_client {
-                let bam_validators = bam_api_client.get_validators().await?;
-                bam_validators
-                    .iter()
-                    .map(|v| v.validator_pubkey.clone())
-                    .collect()
-            } else {
-                HashSet::new()
-            };
-
+        // BAM connection status is collected separately by the BAM snapshot job
+        // (`fetch_bam_connected_set` + `write_bam_snapshot`), so the validator fetch no longer
+        // depends on the BAM API being reachable. An empty set leaves `running_bam` as `None`,
+        // and that field is excluded from the validator upsert anyway.
         let on_chain_data = fetch_chain_data(
             network_validators.as_ref(),
-            bam_validator_set,
+            HashSet::new(),
             self.rpc_client.clone(),
             &self.cluster,
             epoch,
@@ -107,6 +100,23 @@ impl StakePoolManager {
             })
             .collect();
         Ok(validators)
+    }
+
+    /// Fetch the set of validator *identity* pubkeys the BAM API currently reports as
+    /// connected.
+    ///
+    /// Returns an empty set when the BAM API is not configured. Errors from the API are
+    /// propagated so the caller can skip recording a snapshot rather than store a misleading
+    /// one.
+    pub async fn fetch_bam_connected_set(&self) -> Result<HashSet<String>> {
+        let Some(ref bam_api_client) = self.bam_api_client else {
+            return Ok(HashSet::new());
+        };
+        let bam_validators = bam_api_client.get_validators().await?;
+        Ok(bam_validators
+            .iter()
+            .map(|v| v.validator_pubkey.clone())
+            .collect())
     }
 
     pub async fn get_mev_rewards(&self) -> Result<u64> {

--- a/writer-service/src/stake_pool_manager.rs
+++ b/writer-service/src/stake_pool_manager.rs
@@ -79,7 +79,6 @@ impl StakePoolManager {
         // and that field is excluded from the validator upsert anyway.
         let on_chain_data = fetch_chain_data(
             network_validators.as_ref(),
-            HashSet::new(),
             self.rpc_client.clone(),
             &self.cluster,
             epoch,

--- a/writer-service/src/stake_pool_manager.rs
+++ b/writer-service/src/stake_pool_manager.rs
@@ -104,18 +104,22 @@ impl StakePoolManager {
     /// Fetch the set of validator *identity* pubkeys the BAM API currently reports as
     /// connected.
     ///
-    /// Returns an empty set when the BAM API is not configured. Errors from the API are
-    /// propagated so the caller can skip recording a snapshot rather than store a misleading
-    /// one.
-    pub async fn fetch_bam_connected_set(&self) -> Result<HashSet<String>> {
+    /// Returns `None` when the BAM API is not configured (no snapshot should be recorded), and
+    /// `Some(set)` when it was queried successfully — including `Some(empty)` for a valid
+    /// response with zero connected validators, which is a real snapshot rather than a reason
+    /// to skip. Errors from the API are propagated so the caller can skip recording a
+    /// misleading snapshot rather than store one.
+    pub async fn fetch_bam_connected_set(&self) -> Result<Option<HashSet<String>>> {
         let Some(ref bam_api_client) = self.bam_api_client else {
-            return Ok(HashSet::new());
+            return Ok(None);
         };
         let bam_validators = bam_api_client.get_validators().await?;
-        Ok(bam_validators
-            .iter()
-            .map(|v| v.validator_pubkey.clone())
-            .collect())
+        Ok(Some(
+            bam_validators
+                .iter()
+                .map(|v| v.validator_pubkey.clone())
+                .collect(),
+        ))
     }
 
     pub async fn get_mev_rewards(&self) -> Result<u64> {

--- a/writer-service/src/stake_pool_manager.rs
+++ b/writer-service/src/stake_pool_manager.rs
@@ -105,7 +105,7 @@ impl StakePoolManager {
     /// connected.
     ///
     /// Returns `None` when the BAM API is not configured (no snapshot should be recorded), and
-    /// `Some(set)` when it was queried successfully — including `Some(empty)` for a valid
+    /// `Some(set)` when it was queried successfully - including `Some(empty)` for a valid
     /// response with zero connected validators, which is a real snapshot rather than a reason
     /// to skip. Errors from the API are propagated so the caller can skip recording a
     /// misleading snapshot rather than store one.


### PR DESCRIPTION
- Kobe writer service fetches bam api every 10 min -> 30 min if the validator is connected to bam node
- Increment `bam_total_snapshots` every 10 min -> 30min
- Increment `bam_connected_count` if the validator included in the response from bam api
- Calculate bam connection rate as `self.bam_connected_count as f64 / self.bam_total_snapshots as f64`
- Will change kobe-api later